### PR TITLE
Fix handling backslash

### DIFF
--- a/main/index.js
+++ b/main/index.js
@@ -3,7 +3,7 @@
 module.exports = (string) => {
   return string
     .replace(/\s/g, '-')
-    .replace(/[()=:.,!#$@"'/\|?*+&]/g, '')
+    .replace(/[()=:.,!#$@"'/\\|?*+&]/g, '')
     .replace(/^-+|-+$/g, '')
     .replace(/-+/g, '-')
     .toLowerCase();

--- a/test/index.js
+++ b/test/index.js
@@ -10,6 +10,7 @@ const tests = [
   ['Bän...g (bang)', 'bäng-bang'],
   ['    a ', 'a'],
   ['tags/', 'tags'],
+  ['tags\\', 'tags'],
   ['y_u_no', 'y_u_no'],
   ['el-ni\xf1o', 'el-ni\xf1o'],
   ['x荿&', 'x荿'],


### PR DESCRIPTION
This PR fixes a typo where the backslash was unnecessarily escaping `|` and not actually stripping backslashes, which I believe is the intended behavior.